### PR TITLE
Feature/217/reward economy

### DIFF
--- a/modules/coda/assets/coda-add-job-asset.ts
+++ b/modules/coda/assets/coda-add-job-asset.ts
@@ -4,31 +4,32 @@ import { requiredBounty } from '../../math';
 import { PackageDataSchema, PackageData } from '../../packagedata/packagedata-schemas';
 import { Signed, SignedSchema } from '../../signed-schemas';
 import { TrustFactList, TrustFactListSchema } from '../../trustfacts/trustfacts_schema';
-import { CodaJob, CodaJobList, minimalCodaJobSchema, codaJobListSchema, MinimalCodaJob} from '../coda-schemas';
+import { CodaJob, CodaJobList, minimalCodaJobSchema, codaJobListSchema, MinimalCodaJob, codaJobIdSchema, validFacts } from '../coda-schemas';
 
 export class CodaAddJobAsset extends BaseAsset {
     id = 26320;
     name = 'AddJob';
     schema = SignedSchema(minimalCodaJobSchema);
-
-    validate({ asset }: ValidateAssetContext<Signed<MinimalCodaJob>>) {
-        // asset = this.formatAsset({ asset });
+    header;
+    
+    validate({ asset, header }: ValidateAssetContext<Signed<MinimalCodaJob>>) {
+        this.header = header;   
+        asset = this.formatAsset({ asset });   
         if (asset.data.package === "") throw new Error("Package cannot be empty");
         if (asset.data.version === "") throw new Error("version cannot be empty");
         if (asset.data.fact === "") throw new Error("Fact cannot be empty");
+        if (!Object.keys(validFacts).includes(asset.data.fact)) throw new Error("Fact is not valid");
         if (asset.data.bounty < 0) throw new Error("Bounty cannot be negative");
-        
+
         // todo; verify signature (asset.signature)
         if (!asset.signature) throw new Error("Signature is missing!");
     }
 
     async apply({ asset, stateStore }: ApplyAssetContext<Signed<MinimalCodaJob>>) {
-
         const jobsBuffer = await stateStore.chain.get("coda:jobs") as Buffer;
         let { jobs } = codec.decode<CodaJobList>(codaJobListSchema, jobsBuffer);
 
         // calculate activeSpiders and networkCapacity
-
         let totalFacts = 0;
         const accounts: Set<string> = new Set();
 
@@ -55,7 +56,7 @@ export class CodaAddJobAsset extends BaseAsset {
         /* todo; get uid from the following gpg signature: */ asset.signature;
         // and get its gpg uid:
         const accountUid = "test-account";
-
+        
         // Deduct bounty from account
         const accountBuffer = await stateStore.chain.get("account:" + accountUid) as Buffer;
         if (accountBuffer == undefined) throw new Error("Account does not exist in");
@@ -63,9 +64,9 @@ export class CodaAddJobAsset extends BaseAsset {
         account.slingers -= asset.data.bounty;
         if (account.slingers < 0) throw new Error("Bounty is higher than account credit!");
         await stateStore.chain.set("account:" + accountUid, codec.encode(AccountSchema, account));
-
+        
         // Add job to list
-        const job = await this.createCodaJob({ asset: asset.data, stateStore, jobs, account: { uid: accountUid } });
+        const job = await this.createCodaJob({ asset, stateStore, jobs, account: { uid: accountUid } });
         jobs.push(job);
         jobs = await this.removeOldJobs(jobs, stateStore);
         await stateStore.chain.set("coda:jobs", codec.encode(codaJobListSchema, { jobs }));
@@ -77,38 +78,38 @@ export class CodaAddJobAsset extends BaseAsset {
         await this.checkIfPackageAndVersionExist({ asset, stateStore });
 
         const job: CodaJob = {
-            package: asset.package,
-            version: asset.version,
-            fact: asset.fact,
-            date: new Date().toString(),
-            jobID: this.generateRandomNumber(),
-            bounty: asset.bounty,
+            package: asset.data.package,
+            version: asset.data.version,
+            fact: asset.data.fact,
+            date: this.header.height.toString(),
+            jobID: await this.generateJobId({ stateStore }),
+            bounty: asset.data.bounty,
             account: account
         }
         const duplicateIdCheck = jobs.filter(oldJob => oldJob.jobID == job.jobID).length > 0;
         while (duplicateIdCheck) {
-            job.jobID = this.generateRandomNumber();
+            job.jobID = await this.generateJobId({ stateStore });
         }
         return job;
     }
 
     checkIfJobAlreadyExists({ asset }, jobs) {
-        if (jobs.filter(job => job.package == asset.package && 
-            job.fact == asset.fact && job.version == asset.version).length > 0) {
+        if (jobs.filter(job => job.package == asset.data.package && 
+            job.fact == asset.data.fact && job.version == asset.data.version).length > 0) {
             throw new Error("There already exists a job for the given package, version and fact!");
         }
     }
 
     async checkIfPackageAndVersionExist({ asset, stateStore }) {
         // Check if package is in packagedata and if version exists
-        const packageDataBuffer = await stateStore.chain.get("packagedata:" + asset.package) as Buffer;
+        const packageDataBuffer = await stateStore.chain.get("packagedata:" + asset.data.package) as Buffer;
         if (packageDataBuffer === undefined) {
             throw new Error("The given package does not exist in the packageData!");
         }
 
         const packageData = codec.decode<PackageData>(PackageDataSchema, packageDataBuffer);
         const versionFound = packageData.packageReleases.some(version => {
-            return asset.version == version;
+            return asset.data.version == version;
         }); 
         if (!versionFound) {
             throw new Error("The given package version does not exist in the packageData!");
@@ -116,16 +117,14 @@ export class CodaAddJobAsset extends BaseAsset {
     }
 
     async removeOldJobs(jobs: CodaJob[], stateStore: StateStore) {
-
         const jobsToKeep: CodaJob[] = [];
         for (const job of jobs) {
-            const differenceInMilliSeconds = new Date().getTime() - new Date(job.date).getTime();
-            const differenceInMinutes = Math.ceil(differenceInMilliSeconds / (1000 * 60));
-            if (differenceInMinutes <= 10) jobsToKeep.push(job);
-            
+            const differenceInBlockHeight = this.header.height - parseInt(job.date);
+            if (differenceInBlockHeight <= 500) { 
+                jobsToKeep.push(job); 
+            }
             else {
                 // this job is too old; discard it, and payout all rewards!
-
                 const trustFactsBuffer = await stateStore.chain.get("trustfacts:" + job.package);
                 if (trustFactsBuffer !== undefined) {
                     const { facts: allFacts } = codec.decode<TrustFactList>(TrustFactListSchema, trustFactsBuffer);
@@ -147,16 +146,24 @@ export class CodaAddJobAsset extends BaseAsset {
     }
 
     formatAsset({ asset }) {
-        asset.package = asset.package.trim();
-        asset.package = asset.package.toLowerCase();
-        asset.version = asset.version.trim();
-        asset.version = asset.version.replace(/[^\d.-]/g, '');
-        asset.fact = asset.fact.trim();
-        asset.fact = asset.fact.toLowerCase();
+        asset.data.package = asset.data.package.trim();
+        asset.data.package = asset.data.package.toLowerCase();
+        asset.data.version = asset.data.version.trim();
+        asset.data.version = asset.data.version.replace(/[^\d.-]/g, '');
+        asset.data.fact = asset.data.fact.trim();
+        asset.data.fact = asset.data.fact.toLowerCase();
         return asset;
     }
 
-    generateRandomNumber() {
-        return Math.floor(Math.random() * (Math.pow(2, 32)));
+    async generateJobId({ stateStore }) {
+        const jobIdBuffer = await stateStore.chain.get("coda:jobId") as Buffer;
+        const { jobId } = codec.decode(codaJobIdSchema, jobIdBuffer);
+
+        if (jobId == Math.pow(2, 32)) {
+            await stateStore.chain.set("coda:jobId", codec.encode(codaJobIdSchema, { jobId: 0 }));
+        } else {
+            await stateStore.chain.set("coda:jobId", codec.encode(codaJobIdSchema, { jobId: jobId + 1 }));
+        }
+        return jobId;
     }
 }

--- a/modules/coda/assets/coda-add-job-asset.ts
+++ b/modules/coda/assets/coda-add-job-asset.ts
@@ -25,7 +25,7 @@ export class CodaAddJobAsset extends BaseAsset {
 
     async apply({ asset, stateStore }: ApplyAssetContext<Signed<MinimalCodaJob>>) {
         const jobsBuffer = await stateStore.chain.get("coda:jobs") as Buffer;
-        let { jobs } = codec.decode<CodaJobList>(codaJobListSchema, jobsBuffer);
+        const { jobs } = codec.decode<CodaJobList>(codaJobListSchema, jobsBuffer);
 
         // calculate activeSpiders and networkCapacity
         let totalFacts = 0;

--- a/modules/coda/assets/coda-add-job-asset.ts
+++ b/modules/coda/assets/coda-add-job-asset.ts
@@ -1,9 +1,7 @@
 import { ApplyAssetContext, BaseAsset, codec, ValidateAssetContext } from 'lisk-sdk';
 import { Account, AccountSchema } from '../../accounts/accounts-schemas';
-import { requiredBounty } from '../../math';
 import { PackageDataSchema, PackageData } from '../../packagedata/packagedata-schemas';
 import { Signed, SignedSchema } from '../../signed-schemas';
-import { TrustFactList, TrustFactListSchema } from '../../trustfacts/trustfacts_schema';
 import { CodaModule } from '../coda-module';
 import { CodaJob, CodaJobList, minimalCodaJobSchema, codaJobListSchema, MinimalCodaJob, codaJobIdSchema, validFacts, codaBlockHeightSchema } from '../coda-schemas';
 

--- a/modules/coda/coda-module.ts
+++ b/modules/coda/coda-module.ts
@@ -1,4 +1,4 @@
-import { BaseModule, codec } from 'lisk-sdk';
+import { BaseModule, BeforeBlockApplyContext, codec } from 'lisk-sdk';
 import { codaBlockHeightSchema, CodaJob, codaJobIdSchema, CodaJobList, codaJobListSchema, minimalCodaJobSchema } from './coda-schemas';
 import { CodaAddJobAsset } from './assets/coda-add-job-asset';
 import { PackageData, PackageDataSchema } from '../packagedata/packagedata-schemas';

--- a/modules/coda/coda-module.ts
+++ b/modules/coda/coda-module.ts
@@ -2,7 +2,7 @@ import { BaseModule, BeforeBlockApplyContext, codec } from 'lisk-sdk';
 import { codaBlockHeightSchema, CodaJob, codaJobIdSchema, CodaJobList, codaJobListSchema, minimalCodaJobSchema } from './coda-schemas';
 import { CodaAddJobAsset } from './assets/coda-add-job-asset';
 import { PackageData, PackageDataSchema } from '../packagedata/packagedata-schemas';
-import { requiredBounty } from '../math';
+import { requiredBounty, requiredVerifications } from '../math';
 import { TrustFactList, TrustFactListSchema } from '../trustfacts/trustfacts_schema';
 import { Account, AccountSchema } from '../accounts/accounts-schemas';
 
@@ -42,34 +42,10 @@ export class CodaModule extends BaseModule {
 
             return { ...job, bounty: job.bounty.toString(), ...packageData };
         },
-        getMinimumRequiredBounty: async () => {
-            const jobsBuffer = await this._dataAccess.getChainState("coda:jobs") as Buffer;
-            const { jobs } = codec.decode<CodaJobList>(codaJobListSchema, jobsBuffer);
-
-            let totalBounty = BigInt(0);
-            let totalFacts = 0;
-            const spideringAccounts: Set<string> = new Set();
-
-            for (const job of jobs) {
-                totalBounty += job.bounty;
-                const trustFactsBuffer = await this._dataAccess.getChainState("trustfacts:" + job.package);
-                if (trustFactsBuffer != undefined) {
-                    const { facts } = codec.decode<TrustFactList>(TrustFactListSchema, trustFactsBuffer);
-                    totalFacts += facts.length;
-                    for (const fact of facts) {
-                        spideringAccounts.add(fact.account.uid);
-                    }
-                }
-            }
-
-            const uniqueActiveSpiders = spideringAccounts.size;
-            const networkCapacity = totalFacts;
-            
-            return requiredBounty(totalBounty, networkCapacity, uniqueActiveSpiders).toString();
-        },
-        encodeCodaJob: async (asset: Record<string, unknown>) => {
-            return codec.encode(minimalCodaJobSchema, asset).toString('hex');
-        }
+        getMinimumRequiredBounty: async () =>
+            (await CodaModule.requiredBounty( key => this._dataAccess.getChainState(key) )).toString(),
+        encodeCodaJob: async (asset: Record<string, unknown>) =>
+            codec.encode(minimalCodaJobSchema, asset).toString('hex'),
     }
 
     async afterGenesisBlockApply({ stateStore }) {
@@ -100,7 +76,29 @@ export class CodaModule extends BaseModule {
                     const { facts: allFacts } = codec.decode<TrustFactList>(TrustFactListSchema, trustFactsBuffer);
                     const facts = allFacts.filter(fact => fact.jobID == job.jobID);
 
-                    const reward = job.bounty / BigInt(facts.length); // todo; increase reward when there is a surplus of network capacity??
+                    // calculate network capacity (total facts)
+                    const jobsBuffer = await stateStore.chain.get("coda:jobs") as Buffer;
+                    const { jobs } = codec.decode<CodaJobList>(codaJobListSchema, jobsBuffer);
+                    
+                    let totalFacts = 0;
+                    const spideringAccounts: Set<string> = new Set();
+
+                    for (const job of jobs) {
+                        const trustFactsBuffer = await stateStore.chain.get("trustfacts:" + job.package);
+                        if (trustFactsBuffer !== undefined) {
+                            const { facts } = codec.decode<TrustFactList>(TrustFactListSchema, trustFactsBuffer);
+                            totalFacts += facts.length;
+                            for (const fact of facts) {
+                                spideringAccounts.add(fact.account.uid);
+                            }
+                        }
+                    }
+
+                    const networkCapacity = totalFacts;
+                    const networkDemand = requiredVerifications(spideringAccounts.size) * jobs.length;
+
+                    // reward is increased or decreased proportionally to the network capacity-demand ratio
+                    const reward = (BigInt(networkCapacity) * job.bounty) / (BigInt(facts.length * networkDemand));
 
                     for (const fact of facts) {
                         const accountBuffer = await stateStore.chain.get("account:" + fact.account.uid) as Buffer;
@@ -112,5 +110,31 @@ export class CodaModule extends BaseModule {
             }
         }
         await stateStore.chain.set("coda:jobs", codec.encode(codaJobListSchema, { jobsToKeep }));
+    }
+
+    static async requiredBounty( getChainState: (key: string) => Promise<Buffer | undefined> ) {
+        const jobsBuffer = await getChainState("coda:jobs") as Buffer;
+        const { jobs } = codec.decode<CodaJobList>(codaJobListSchema, jobsBuffer);
+        
+        let totalFacts = 0;
+        let totalBounty = BigInt(0);
+        const spideringAccounts: Set<string> = new Set();
+
+        for (const job of jobs) {
+            totalBounty += job.bounty;
+            const trustFactsBuffer = await getChainState("trustfacts:" + job.package);
+            if (trustFactsBuffer !== undefined) {
+                const { facts } = codec.decode<TrustFactList>(TrustFactListSchema, trustFactsBuffer);
+                totalFacts += facts.length;
+                for (const fact of facts) {
+                    spideringAccounts.add(fact.account.uid);
+                }
+            }
+        }
+
+        const uniqueActiveSpiders = spideringAccounts.size;
+        const networkCapacity = totalFacts;
+
+        return requiredBounty(totalBounty, networkCapacity, uniqueActiveSpiders);
     }
 }

--- a/modules/coda/coda-module.ts
+++ b/modules/coda/coda-module.ts
@@ -1,5 +1,5 @@
 import { BaseModule, codec } from 'lisk-sdk';
-import { CodaJob, CodaJobList, codaJobListSchema, minimalCodaJobSchema } from './coda-schemas';
+import { CodaJob, codaJobIdSchema, CodaJobList, codaJobListSchema, minimalCodaJobSchema } from './coda-schemas';
 import { CodaAddJobAsset } from './assets/coda-add-job-asset';
 import { PackageData, PackageDataSchema } from '../packagedata/packagedata-schemas';
 import { requiredBounty } from '../math';
@@ -20,7 +20,6 @@ export class CodaModule extends BaseModule {
             return jobsFixed;
         },
         getRandomJob: async () => {
-
             const jobsBuffer = await this._dataAccess.getChainState("coda:jobs") as Buffer;
             const { jobs } = codec.decode<CodaJobList>(codaJobListSchema, jobsBuffer);
 
@@ -74,6 +73,8 @@ export class CodaModule extends BaseModule {
 
     async afterGenesisBlockApply({ stateStore }) {
         const jobsBuffer = codec.encode(codaJobListSchema, { jobs: [] });
+        const jobId = codec.encode(codaJobIdSchema, { jobId: 0 });
         await stateStore.chain.set("coda:jobs", jobsBuffer);
+        await stateStore.chain.set("coda:jobId", jobId);
     }
 }

--- a/modules/coda/coda-module.ts
+++ b/modules/coda/coda-module.ts
@@ -1,4 +1,4 @@
-import { BaseModule, BeforeBlockApplyContext, codec } from 'lisk-sdk';
+import { BaseModule, codec } from 'lisk-sdk';
 import { codaBlockHeightSchema, CodaJob, codaJobIdSchema, CodaJobList, codaJobListSchema, minimalCodaJobSchema } from './coda-schemas';
 import { CodaAddJobAsset } from './assets/coda-add-job-asset';
 import { PackageData, PackageDataSchema } from '../packagedata/packagedata-schemas';

--- a/modules/coda/coda-schemas.ts
+++ b/modules/coda/coda-schemas.ts
@@ -67,6 +67,18 @@ export interface MinimalCodaJob extends Record<string, unknown> {
     bounty: bigint;
 }
 
+export const codaBlockHeightSchema: Schema = {
+    $id: 'coda/blockheight',
+    type: 'object',
+    required: ["blockHeight"],
+    properties: {
+        blockHeight: {
+            dataType: 'uint32',
+            fieldNumber: 1
+        }
+    }
+}
+
 export const codaJobSchema: Schema = {
     $id: 'coda/add-job',
     type: 'object',

--- a/modules/coda/coda-schemas.ts
+++ b/modules/coda/coda-schemas.ts
@@ -1,7 +1,7 @@
 import { Schema } from "lisk-sdk";
 import { AccountId, AccountIdSchema } from "../accounts/accounts-schemas";
 
-export const validFacts: any = {
+export const validFacts = {
     github: [
         "gh_contributor_count",
         "gh_user_count",
@@ -105,6 +105,18 @@ export const codaJobSchema: Schema = {
         }
     }
 };
+
+export const codaJobIdSchema: Schema = {
+    $id: 'coda/job-id',
+    type: 'object',
+    required: ["jobId"],
+    properties: {
+        jobId: {
+            dataType: 'uint32',
+            fieldNumber: 1
+        }
+    }
+}
 
 export const codaJobListSchema: Schema = {
     $id: 'coda/job-list',

--- a/modules/packagedata/assets/packagedata-add-data-asset.ts
+++ b/modules/packagedata/assets/packagedata-add-data-asset.ts
@@ -1,6 +1,5 @@
 import { BaseAsset, codec } from 'lisk-sdk';
 import { PackageDataSchema, PackageData, PackageDataListSchema, PackageDataList } from "../packagedata-schemas";
-// import { CodaJobList, codaJobListSchema, CodaJob, validFacts } from '../../coda/coda-schemas';
 
 export class PackageDataAddDataAsset extends BaseAsset {
     id = 63280;


### PR DESCRIPTION
Rewards now increase/decrase depending on the network supply-demand factor. This should stimulate the economy to make use of the complete network capacity, without overflooding it.

Normally; bounty of a job is divided equally among all participants that spidered this fact. With this change this reward is first multiplied by the (networkCapacity / networkDemand) ratio.