### PR TITLE
Feature/301/gpg refactor

### DIFF
--- a/common/gpg-verification.ts
+++ b/common/gpg-verification.ts
@@ -1,0 +1,47 @@
+import { AccountId, AccountURL } from '../modules/accounts/accounts-schemas';
+import { exec, spawnSync } from "child_process";
+import { promisify } from 'util';
+import { codec, Schema } from 'lisk-sdk';
+import { writeFileSync } from 'fs';
+import { unlink } from 'fs/promises';
+import { Signed } from '../modules/signed-schemas';
+const exec$ = promisify(exec);
+
+export class GPG {
+
+    // all GPG key URLs should be provided by github.com
+    static readonly urlPattern = /^https:\/\/github\.com\/([a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})\.gpg$/;
+
+    static validateURL = ( { url } : AccountURL ) => this.urlPattern.test(url);
+
+    // import a GPG key from a URL to the local GPG keyring
+    // returns the account UID of the imported key
+    static async import( { url } : AccountURL ) : Promise<AccountId> {
+        this.validateURL({ url });
+
+        const { stderr } = await exec$(`curl ${url} | gpg --import`);
+        const accountUid = /key \w*(\w{16})/.exec(stderr)?.[1];
+        if (accountUid === undefined) throw new Error(`Unable to find the uid for the GPG key from ${url}`);
+
+        return { uid: accountUid };
+    }
+
+    // verify the signature of a signed object
+    // returns the account UID of the key used to sign the object
+    static verify<T extends object>(asset : Signed<T>, schema : Schema) : AccountId {
+        const encoded = codec.encode(schema, asset.data).toString('hex');
+
+        const random = Math.random().toString().slice(2);
+        writeFileSync("/tmp/signature-" + random, asset.signature);
+        writeFileSync("/tmp/data-" + random, encoded);
+        const { stderr, status } = spawnSync(`gpg`, ["--verify", "/tmp/signature-" + random, "/tmp/data-" + random]);
+        unlink("/tmp/signature-" + random);
+        unlink("/tmp/data-" + random);
+
+        const accountUid = /key \w*(\w{16})/.exec(stderr.toString())?.[1];
+        if (status !== 2) throw new Error("GPG signature verification failed");
+        if (accountUid === undefined) throw new Error("GPG key is unknown");
+
+        return { uid: accountUid };
+    }
+}

--- a/modules/accounts/assets/accounts-add-asset.ts
+++ b/modules/accounts/assets/accounts-add-asset.ts
@@ -1,36 +1,25 @@
 //import { Http2ServerRequest } from 'http2';
 import { ApplyAssetContext, BaseAsset, codec, ValidateAssetContext } from 'lisk-sdk';
 import { AccountSchema, Account, AccountURLSchema, AccountURL } from '../accounts-schemas';
-import { exec } from 'child_process';
+import { GPG } from '../../../common/gpg-verification';
 
 export class AccountsAddAsset extends BaseAsset {
     id = 26660;
     name = 'AccountsAdd';
     schema = AccountURLSchema;
 
-    validate({ asset }: ValidateAssetContext<AccountURL>) {
-        const regex = /^https:\/\/github\.com\/([a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})\.gpg$/; // https://github.com/[username].gpg
-        if (!regex.test(asset.url)) throw new Error('url should be of the form https://github.com/[username].gpg');
+    validate({ asset : accountURL }: ValidateAssetContext<AccountURL>) {
+        if (!GPG.validateURL(accountURL)) throw new Error('url should be of the form https://github.com/[username].gpg');
     }
 
-    async apply({ asset, stateStore }: ApplyAssetContext<AccountURL>) {
+    async apply({ asset : accountURL, stateStore }: ApplyAssetContext<AccountURL>) {
+        const accountUid = GPG.import(accountURL);
 
-        //import the gpg key from asset.url
-        const output = await new Promise<string>((res,rej) => {
-            exec(`curl ${asset.url} | gpg --import`, function(error, _stdout, stderr) {
-                if (error) rej (error);
-                else res(stderr);
-            });
-        });
-
-        //Extract the accountUID from the output
-        const regex = /key \w*(\w{16})/;
-        const match = regex.exec(output);
-        const accountUid = match?.[1];
-
+        // when the account is already known, we don't need to do anything
         const accountsBuffer = await stateStore.chain.get("account:" + accountUid) as Buffer;
         if (accountsBuffer !== undefined) return;
 
+        // create a new account with 5000 reward tokens
         const account : Account = { slingers: BigInt(5000) };
         await stateStore.chain.set("account:" + accountUid, codec.encode(AccountSchema, account));
     }

--- a/modules/accounts/assets/accounts-add-asset.ts
+++ b/modules/accounts/assets/accounts-add-asset.ts
@@ -8,19 +8,26 @@ export class AccountsAddAsset extends BaseAsset {
     name = 'AccountsAdd';
     schema = AccountURLSchema;
 
-    validate({ asset : accountURL }: ValidateAssetContext<AccountURL>) {
-        if (!GPG.validateURL(accountURL)) throw new Error('url should be of the form https://github.com/[username].gpg');
+    validate({ asset : { url } }: ValidateAssetContext<AccountURL>) {
+        if (!GPG.validateURL(url)) throw new Error('url should be of the form https://github.com/[username].gpg');
     }
 
-    async apply({ asset : accountURL, stateStore }: ApplyAssetContext<AccountURL>) {
-        const accountUid = GPG.import(accountURL);
+    async apply({ asset : { url }, stateStore }: ApplyAssetContext<AccountURL>) {
+        console.log(`Adding GPG key from ${url}`);
+
+        const uid = await GPG.import( url );
 
         // when the account is already known, we don't need to do anything
-        const accountsBuffer = await stateStore.chain.get("account:" + accountUid) as Buffer;
-        if (accountsBuffer !== undefined) return;
+        const accountsBuffer = await stateStore.chain.get("account:" + uid) as Buffer;
+        if (accountsBuffer !== undefined) {
+            console.log(`Account from ${url} already known as ${uid}`);
+            return;
+        }
 
         // create a new account with 5000 reward tokens
         const account : Account = { slingers: BigInt(5000) };
-        await stateStore.chain.set("account:" + accountUid, codec.encode(AccountSchema, account));
+        await stateStore.chain.set("account:" + uid, codec.encode(AccountSchema, account));
+
+        console.log(`Added account ${uid} from ${url}`);
     }
 }

--- a/modules/coda/assets/coda-add-job-asset.ts
+++ b/modules/coda/assets/coda-add-job-asset.ts
@@ -35,7 +35,7 @@ export class CodaAddJobAsset extends BaseAsset {
 
         // Deduct bounty from account
         const accountBuffer = await stateStore.chain.get("account:" + accountUid) as Buffer;
-        if (accountBuffer == undefined) throw new Error("Account does not exist in");
+        if (accountBuffer == undefined) throw new Error("Account does not exist");
         const account = codec.decode<Account>(AccountSchema, accountBuffer);
         account.slingers -= asset.data.bounty;
         if (account.slingers < 0) throw new Error("Bounty is higher than account credit!");

--- a/modules/coda/assets/coda-add-job-asset.ts
+++ b/modules/coda/assets/coda-add-job-asset.ts
@@ -3,9 +3,8 @@ import { Account, AccountSchema } from '../../accounts/accounts-schemas';
 import { PackageDataSchema, PackageData } from '../../packagedata/packagedata-schemas';
 import { Signed, SignedSchema } from '../../signed-schemas';
 import { CodaModule } from '../coda-module';
-import { spawnSync } from 'child_process';
-import { unlink, writeFileSync } from 'fs';
 import { CodaJob, CodaJobList, minimalCodaJobSchema, codaJobListSchema, MinimalCodaJob, codaJobIdSchema, validFacts, codaBlockHeightSchema } from '../coda-schemas';
+import { GPG } from '../../../common/gpg-verification';
 
 export class CodaAddJobAsset extends BaseAsset {
     id = 26320;
@@ -18,67 +17,21 @@ export class CodaAddJobAsset extends BaseAsset {
         if (asset.data.version === "") throw new Error("version cannot be empty");
         if (asset.data.fact === "") throw new Error("Fact cannot be empty");
         if (!validFacts.flatMap(a => a.facts).includes(asset.data.fact)) throw new Error("Fact is not valid");
-        if (asset.data.bounty < 0) throw new Error("Bounty cannot be negative");
-
-        // todo; verify signature (asset.signature)
         if (!asset.signature) throw new Error("Signature is missing!");
-
-        //---start of gpg verification---
-        // generate random number that identifies this gpg verification
-        const random = Math.random().toString().slice(2);
-        // write asset.signature to file
-        writeFileSync("/tmp/signature-" + random, asset.signature);
-        const encoded = codec.encode(minimalCodaJobSchema, asset.data).toString('hex');
-        // write data to fle
-        writeFileSync("/tmp/data-" + random, encoded);
-
-        // verify signature        
-        const result = spawnSync(`gpg`, ["--verify", "/tmp/signature-" + random, "/tmp/data-" + random]);
-
-        // delete the files
-        unlink("/tmp/signature-" + random, () => 0);
-        unlink("/tmp/data-" + random, () => 0);
-
-        // extract the key
-        const regex = /key \w*(\w{16})/;        
-        const accountUid = regex.exec(result.stderr?.toString())?.[1];
-
-        // if there is no key, the verification failed
-        if (result.status != 2 || accountUid == null) {throw new Error("gpg verification failed");}
-        //---end of gpg verification---
+        
+        // will throw an error when the signature is invalid
+        GPG.verify(asset, minimalCodaJobSchema);
     }
 
     async apply({ asset, stateStore }: ApplyAssetContext<Signed<MinimalCodaJob>>) {
+        const { uid: accountUid } = GPG.verify(asset, minimalCodaJobSchema);
+
         const jobsBuffer = await stateStore.chain.get("coda:jobs") as Buffer;
         const { jobs } = codec.decode<CodaJobList>(codaJobListSchema, jobsBuffer);
 
         // check if bounty is higher than minimum required
         const rB = await CodaModule.requiredBounty( key => stateStore.chain.get(key) );
         if (asset.data.bounty < rB) throw new Error("Bounty is too low!");
-
-        //---start of gpg verification (for accountUid extraction)---
-        // generate random number that identifies this gpg verification
-        const random = Math.random().toString().slice(2);
-        // write asset.signature to file
-        writeFileSync("/tmp/signature-" + random, asset.signature);
-        const encoded = codec.encode(minimalCodaJobSchema, asset.data);
-        // write data to fle
-        writeFileSync("/tmp/data-" + random, encoded);
-
-        // verify signature        
-        const result = spawnSync(`gpg`, ["--verify", "/tmp/signature-" + random, "/tmp/data-" + random]);
-
-        // delete the files
-        unlink("/tmp/signature-" + random, () => 0);
-        unlink("/tmp/data-" + random, () => 0);
-
-        // extract the key
-        const regex = /key \w*(\w{16})/;        
-        const accountUid = regex.exec(result.stderr?.toString())?.[1];
-
-        // if there is no key, the verification failed
-        if (result.status != 2 || accountUid == null) throw new Error("gpg verification failed");
-        //---end of gpg verification---
 
         // Deduct bounty from account
         const accountBuffer = await stateStore.chain.get("account:" + accountUid) as Buffer;

--- a/modules/coda/assets/coda-add-job-asset.ts
+++ b/modules/coda/assets/coda-add-job-asset.ts
@@ -39,11 +39,11 @@ export class CodaAddJobAsset extends BaseAsset {
         const account = codec.decode<Account>(AccountSchema, accountBuffer);
         account.slingers -= asset.data.bounty;
         if (account.slingers < 0) throw new Error("Bounty is higher than account credit!");
-        await stateStore.chain.set("account:" + uid, codec.encode(AccountSchema, account));
         
         // Add job to list
         const job = await this.createCodaJob({ asset, stateStore, jobs, account: { uid } });
         jobs.push(job);
+        await stateStore.chain.set("account:" + uid, codec.encode(AccountSchema, account));
         await stateStore.chain.set("coda:jobs", codec.encode(codaJobListSchema, { jobs }));
     }
 

--- a/modules/coda/coda-module.ts
+++ b/modules/coda/coda-module.ts
@@ -61,8 +61,10 @@ export class CodaModule extends BaseModule {
         },
         getMinimumRequiredBounty: async () =>
             (await CodaModule.requiredBounty( key => this._dataAccess.getChainState(key) )).toString(),
-        encodeCodaJob: async (asset: Record<string, unknown>) =>
-            codec.encode(minimalCodaJobSchema, asset).toString('hex'),
+        encodeCodaJob: async function(asset: Record<string, unknown>) {
+            asset.bounty = BigInt(asset.bounty as string | number);
+            return codec.encode(minimalCodaJobSchema, asset).toString('hex');
+        },
         //return a string of all valid facts
         listAllFacts: async () => {
             return validFacts;

--- a/modules/signed-schemas.ts
+++ b/modules/signed-schemas.ts
@@ -1,6 +1,6 @@
 import { Schema } from "lisk-sdk";
 
-export interface Signed<T> {
+export interface Signed<T extends object> {
     signature: string;
     data: T;
 }


### PR DESCRIPTION
Refactored importing GPG keys (from url) and verifying GPG signatures into a separate typescript module. See common/gpg-verification.ts

- manually tested adding account, encoding & adding spiderjob, encoding & adding trustfact, reading trustfact. Seems to be working correctly

- this also fixed a bug (BigInt mixed with other types) that @gijs-blanken came accross while calling the encodeCodaJob action.