### PR TITLE
disable gpg and bounty when env vars set

### DIFF
--- a/common/gpg-verification.ts
+++ b/common/gpg-verification.ts
@@ -38,11 +38,14 @@ export class GPG {
         unlink("/tmp/data-" + random);
 
         const accountUid = /key \w*(\w{16})/.exec(stderr.toString())?.[1];
+
         if (status !== 0) {
             console.log(stderr.toString());
-            throw new Error("GPG signature verification failed");
+            if (process.env.ACCEPT_BAD_SIGNATURES) console.error("GPG signature verification failed! ACCEPT_BAD_SIGNATURES is set, so continuing anyway.");
+            else throw new Error("GPG signature verification failed");
         }
-        if (accountUid === undefined) throw new Error("GPG key is unknown");
+
+        if (accountUid === undefined) throw new Error("Unable to find the uid for the provided GPG key");
 
         return accountUid;
     }


### PR DESCRIPTION
Read the following environment variables:

    ACCEPT_BAD_SIGNATURES
    ACCEPT_INSUFFICIENT_BOUNTY

And when they exist (doesn't really matter what they're set to, f.e. "true") act accodringly.
A warning will be shown in stdout every time this rule causes invalid transactions to be accepted.

@gijs-blanken laat maar weten of dit werkt vanuit Cosy.